### PR TITLE
Adds simplified object literal syntax

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,7 @@ module.exports = {
         'no-duplicate-imports': 'error',
         // risk only exist with semi-colon auto insertion. Not our case.
         'no-plusplus': 'off',
+        'no-param-reassign': 'off',
         'no-underscore-dangle': ['error', {
             'allowAfterSuper': true,
             'allowAfterThis': true,


### PR DESCRIPTION
It's now possible to register middlewares by passing an object which implements only the functions you want to handle.

```javascript
service.register({
    // Only cares about the response
    onResponse(resp) {
        return resp.data;
    }
});
```

I also changed the order in which the middleware are called. It goes like this:

1. `onRequest`
    1. First middleware
    1. Second middleware
1. `onResponse`
    1. Second middleware
    1. First middleware

