### PR TITLE
Fix property spreading on example

### DIFF
--- a/docs/examples/locale-middleware.md
+++ b/docs/examples/locale-middleware.md
@@ -10,8 +10,9 @@ export default class LocaleMiddleware {
     
     onRequest(config) {
         config.headers = {
-            locale: this.i18n.lang,
-            ...config.headers
+            ...config.headers,
+            locale: this.i18n.lang
+
         };
         return config;
     }


### PR DESCRIPTION
Spread operator should be the first property so the `locale` property can over ride if there is one already set before.