### PR TITLE
Fix auth example

### DIFF
--- a/docs/examples/auth-middleware.md
+++ b/docs/examples/auth-middleware.md
@@ -20,8 +20,8 @@ export default class AuthMiddleware {
             ...err.config.headers,
             Authorization: `Bearer ${token}`
           }
-        })
-        .catch(function (error) {
+        }))
+        .catch((error) => {
           console.log('Refresh login error: ', error);
           throw error;
         });


### PR DESCRIPTION
Add missing ```)```
Rewrite catch statement to match the code style used in the ```.then``` block