### PR TITLE
Pin axios peer dependency to <1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@babel/preset-env": "^7.3.4",
-        "axios": "^1.4.0",
+        "axios": "^1.1.3",
         "axios-mock-adapter": "^1.21.5",
         "codecov": "^3.2.0",
         "cross-env": "^7.0.3",
@@ -2960,9 +2960,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
-      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.3.tgz",
+      "integrity": "sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==",
       "dev": true,
       "dependencies": {
         "follow-redirects": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -44,11 +44,11 @@
     "http"
   ],
   "peerDependencies": {
-    "axios": ">= 0.17.1"
+    "axios": ">=0.17.1 <1.2.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.3.4",
-    "axios": "^1.4.0",
+    "axios": "^1.1.3",
     "axios-mock-adapter": "^1.21.5",
     "codecov": "^3.2.0",
     "cross-env": "^7.0.3",

--- a/test/specs/service.spec.js
+++ b/test/specs/service.spec.js
@@ -18,6 +18,26 @@ describe('Middleware service', () => {
     mock.restore();
   });
 
+  it('works with the global axios instance', () => {
+    expect.assertions(3);
+
+    const axiosAdapter = axios.defaults.adapter;
+    const globalMock = new MockAdapter(axios);
+    const globalService = new Service(axios);
+
+    globalMock.onAny().reply((config) => [200, config.param]);
+
+    return axios().then(() => {
+      expect(axios.defaults.adapter).not.toBe(axiosAdapter);
+      expect(axios.defaults.adapter).toBeInstanceOf(Function);
+
+      globalService.unsetHttp();
+      globalMock.restore();
+
+      expect(axios.defaults.adapter).toBe(axiosAdapter);
+    });
+  });
+
   it('throws when adding the same middleware instance', () => {
     const middleware = {};
 
@@ -70,6 +90,7 @@ describe('Middleware service', () => {
 
   it('can catch current request promise', () => {
     expect.assertions(1);
+
     service.register({
       onSync(promise) {
         expect(promise).toBeInstanceOf(Promise);


### PR DESCRIPTION
This addresses issue:
- https://github.com/emileber/axios-middleware/issues/62

It's unfortunately not a fix, but a clarification on which versions are currently supported by this library.

Until Axios offers a clear way to enhance the default adapter (e.g. by [exporting `getAdapter`](https://github.com/axios/axios/pull/5324)), I won't be updating this library further. 